### PR TITLE
Add keymap support to remote HID print

### DIFF
--- a/Overlook/InputManager.swift
+++ b/Overlook/InputManager.swift
@@ -425,7 +425,8 @@ class InputManager: ObservableObject {
 
         Task {
             do {
-                try await client.hidPrint(text: trimmed)
+                let keymap: String? = try? await client.getSystemConfig().keymap
+                try await client.hidPrint(text: trimmed, keymap: keymap)
             } catch {
                 print("Paste to remote failed: \(error)")
             }
@@ -1041,3 +1042,4 @@ extension InputManager {
         return true
     }
 }
+


### PR DESCRIPTION
- Fetch remote system keymap before sending text
- Pass keymap to `hidPrint` for accurate input
- Improves reliability of remote paste operations

Closes #6 